### PR TITLE
Switched gatt implementation (superuser no longer needed) + decoded status + python3 + ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Usage example:
 - http://torsten-traenkner.de/wissen/smarthome/heizung.php
 
 ## TODO
-- Support flags
+- Support status write
 - Support timer
 - Write tests
 - Python3

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ From the software point of view, "Comet Blue" is an BLE (Bluetooth Low Energy) d
 
 This project provides python library and command line tool which may be used to control "Comet Blue" from any linux system equipped with Bluetooth adapter (USB Bluetooth 4.0 dongle, for example).
 
+This project is fork of https://github.com/im-0/cometblue rewrited with library https://github.com/getsenic/gatt-python
+
 ## Installation
 From sources:
 ```
@@ -29,6 +31,8 @@ Usage: cometblue [OPTIONS] COMMAND [ARGS]...
 
 Options:
   -a, --adapter TEXT              Bluetooth adapter interface  [default: hci0]
+  -p, --poweron                   Power ON/OFF adapter if needed  [default:
+                                  False]
   -f, --formatter [json|human-readable|shell-var]
                                   Output formatter  [default: human-readable]
   -L, --log-level TEXT            [default: error]
@@ -87,12 +91,12 @@ Commands:
   device_name         Get device name
   firmware_revision   Get firmware revision
   firmware_revision2  Get firmware revision #2 (requires PIN)
-  flags               Get flags (requires PIN)
   holidays            Get configured holidays (requires PIN)
   lcd_timer           Get LCD timer (requires PIN)
   manufacturer_name   Get manufacturer name
   model_number        Get model number
   software_revision   Get software revision
+  status              Get status (requires PIN)
   temperatures        Get temperatures (requires PIN)
 ```
 Usage examples:
@@ -137,6 +141,7 @@ Commands:
   holiday       Set period and temperature for holiday...
   lcd_timer     Set LCD timer (requires PIN)
   pin           Set PIN (requires PIN)
+  status        Set status (requires PIN)
   temperatures  Set temperatures (requires PIN)
 ```
 Usage examples:
@@ -215,7 +220,6 @@ Usage example:
 - http://torsten-traenkner.de/wissen/smarthome/heizung.php
 
 ## TODO
-- Support status write
 - Support timer
 - Write tests
 

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ Usage examples:
 2016-03-27 18:32:00
 
 # cometblue device -p 0 E0:E5:CF:D6:98:53 get temperatures
-Current temperature: 23.0 °C
-Temperature for manual mode: 16.0 °C
-Target temperature low: 16.0 °C
-Target temperature high: 21.0 °C
-Offset temperature: 0.0 °C
-Window open detection: 4
-Window open minutes: 10
+Current temperature:    23.0 °C
+Temperature for manual mode:    16.0 °C
+Target temperature low:         16.0 °C
+Target temperature high:        21.0 °C
+Offset temperature:     0.0 °C
+Window open detection:  4
+Window open minutes:    10
 
 # cometblue device E0:E5:CF:D6:98:53 get device_name  # no PIN required
 Comet Blue

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Commands:
   firmware_revision   Get firmware revision
   firmware_revision2  Get firmware revision #2 (requires PIN)
   holidays            Get configured holidays (requires PIN)
-  lcd_timer           Get LCD timer (requires PIN)
+  lcd_timeout         Get LCD timeout settings (requires PIN)
   manufacturer_name   Get manufacturer name
   model_number        Get model number
   software_revision   Get software revision
@@ -139,7 +139,7 @@ Commands:
   datetime      Set time and date (requires PIN)
   day           Set periods per days of the week (requires...
   holiday       Set period and temperature for holiday...
-  lcd_timer     Set LCD timer (requires PIN)
+  lcd_timeout   Set LCD blank timeout (requires PIN)
   pin           Set PIN (requires PIN)
   status        Set status (requires PIN)
   temperatures  Set temperatures (requires PIN)

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ This project provides python library and command line tool which may be used to 
 From sources:
 ```
 # Install dependencies
-pip install -r requirements.txt
+pip3 install -r requirements.txt
 # Install cometblue
-python setup.py install
+python3 setup.py install
 ```
-Using *pip*:
+Using *pip* (unsupported):
+(currently only original project, this fork is unsupported)
 ```
-pip install cometblue
+pip3 install cometblue
 ```
 
 ## Command line tool
@@ -217,7 +218,6 @@ Usage example:
 - Support status write
 - Support timer
 - Write tests
-- Python3
 
 ## Notes
 Tool and library may not work as expected because it is not well tested. Patches and bugreports are always welcome.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Temperature for manual mode:    16.0 °C
 Target temperature low:         16.0 °C
 Target temperature high:        21.0 °C
 Offset temperature:     0.0 °C
-Window open detection:  4
+Window open sensitivity:        4 (1 = low, 4 = high, 8 = mid)
 Window open minutes:    10
 
 # cometblue device E0:E5:CF:D6:98:53 get device_name  # no PIN required

--- a/cometblue/cli.py
+++ b/cometblue/cli.py
@@ -305,7 +305,8 @@ def _device_get_holidays(ctx):
 
 @click.group(
         'get',
-        help='Get value')
+        help='Get value',
+        chain=True)
 def _device_get():
     pass
 
@@ -393,7 +394,8 @@ def _device_set_holiday(ctx, holiday, start, end, temperature):
 
 @click.group(
         'set',
-        help='Set value (always requires PIN)')
+        help='Set value (always requires PIN)',
+        chain=True)
 def _device_set():
     pass
 
@@ -457,7 +459,9 @@ def _device_restore(ctx, file_name):
 
 @click.group(
         'device',
-        help='Get or set values')
+        short_help='Get or set values'
+        #, chain=True
+        )
 @click.option(
         '--pin', '-p',
         default=None,

--- a/cometblue/cli.py
+++ b/cometblue/cli.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 expandtab
 from __future__ import absolute_import
 
 import datetime

--- a/cometblue/cli.py
+++ b/cometblue/cli.py
@@ -104,6 +104,22 @@ class _HumanReadableFormatter(object):
         self._stream.write(text)
         self._stream.flush()
 
+    def print_status(self, value):
+        text = ''
+        text += 'Temperature satisfied:\t%r\n' % value['satisfied']
+        text += 'Child-lock:\t%r\n' % value['childlock']
+        text += 'Manual mode is:\t%r\n' % value['manual_mode']
+        text += 'Adapting:\t%r\n' % value['adapting']
+        text += 'Not ready:\t%r\n' % value['not_ready']
+        text += 'Motor moving:\t%r\n' % value['motor_moving']
+        text += 'Install procedure running:\t%r\n' % value['installing']
+        text += 'Antifrost active:\t%r\n' % value['antifrost_activated']
+        text += 'Low battery alert:\t%r\n' % value['low_battery']
+        text += 'State dword:\t0x%08X\n' % value['state_as_dword']
+        text += 'Unknown state:\t0x%08X\n' % value['unused_bits']
+        self._stream.write(text)
+        self._stream.flush()
+
     def print_lcd_timer(self, value):
         self._print_simple('%02u:%02u' % (value['preload'], value['current']))
 

--- a/cometblue/cli.py
+++ b/cometblue/cli.py
@@ -576,6 +576,38 @@ class _SetterFunctions(object):
         return set_datetime
 
     @staticmethod
+    def status(real_setter):
+
+        @click.option('+c/-c', '--childlock/--no-childlock', 'childlock', is_flag=True, default=None, help='Enable/disable childlock')
+        @click.option('+m/-m', '--manual-mode', '--auto-mode', 'manual_mode', is_flag=True, default=None, help='Enable/disable manual mode')
+        @click.option('+a', '--adapt', 'adapting', is_flag=True, default=None, help='Re-adapt (make sure device is mounted)')
+        @click.pass_context
+        def set_status(ctx, childlock, manual_mode, adapting):
+            keys = ['childlock', 'manual_mode', 'adapting']
+            vals = [childlock, manual_mode, adapting]
+
+            status = {}
+            for i in range(len(keys)):
+                if vals[i] is None:
+                    continue
+                status[keys[i]] = vals[i]
+
+            if not status:
+                raise RuntimeError(
+                        'No status flags to update, try "status -h"')
+
+            if ctx.obj.device._device.is_connected():
+                current = ctx.obj.device.get_status()
+                current = dict((k, v) for k, v in current.items() if k in keys)
+                for k, v in status.items():
+                    current[k] = v
+                status = current
+
+            real_setter(ctx, status)
+
+        return set_status
+
+    @staticmethod
     def temperatures(real_setter):
         @click.option(
                 '--temp-manual', '-m',

--- a/cometblue/cli.py
+++ b/cometblue/cli.py
@@ -101,7 +101,7 @@ class _HumanReadableFormatter(object):
         text += 'Target temperature low:\t%.01f °C\n' % value['target_temp_l']
         text += 'Target temperature high:\t%.01f °C\n' % value['target_temp_h']
         text += 'Offset temperature:\t%.01f °C\n' % value['offset_temp']
-        text += 'Window open detection:\t%u\n' % value['window_open_detection']
+        text += 'Window open sensitivity:\t%u (1 = low, 4 = high, 8 = mid)\n' % value['window_open_detection']
         text += 'Window open minutes:\t%u\n' % value['window_open_minutes']
         self._stream.write(text)
         self._stream.flush()
@@ -658,7 +658,7 @@ class _SetterFunctions(object):
                 '--window-open-detect', '-w',
                 type=int,
                 default=None,
-                help='Window open detection')
+                help='Window open sensitivity (1 = low, 4 = high, 8 = mid)')
         @click.option(
                 '--window-open-minutes', '-W',
                 type=int,

--- a/cometblue/cli.py
+++ b/cometblue/cli.py
@@ -125,8 +125,9 @@ class _HumanReadableFormatter(object):
         self._stream.write(text)
         self._stream.flush()
 
-    def print_lcd_timer(self, value):
-        self._print_simple('%02u:%02u' % (value['preload'], value['current']))
+    def print_lcd_timeout(self, value):
+        self._print_simple('Default timeout:\t%02u' % (value['default'])
+        self._print_simple('Timeout in progress:\t%02u' % (value['current']))
 
     def print_days(self, value):
         table = zip(
@@ -211,9 +212,9 @@ class _ShellVarFormatter(object):
                         var_name.upper(), shellescape.quote(val_str)))
         self._stream.flush()
 
-    def print_lcd_timer(self, value):
-        self._print_simple('lcd_timer_preload', '%u' % value['preload'])
-        self._print_simple('lcd_timer_current', '%u' % value['current'])
+    def print_lcd_timeout(self, value):
+        self._print_simple('lcd_timeout_default', '%u' % value['default'])
+        self._print_simple('lcd_timeout_current', '%u' % value['current'])
 
     def print_days(self, value):
         for day_n, day in zip(itertools.count(), value):
@@ -742,18 +743,18 @@ class _SetterFunctions(object):
         return set_temperatures
 
     @staticmethod
-    def lcd_timer(real_setter):
+    def lcd_timeout(real_setter):
         @click.argument(
                 'value',
                 required=True)
         @click.pass_context
-        def set_lcd_timer(ctx, value):
-            lcd_timer = {
-                'preload': int(value),
+        def set_lcd_timeout(ctx, value):
+            lcd_timeout = {
+                'default': int(value),
             }
-            real_setter(ctx, lcd_timer)
+            real_setter(ctx, lcd_timeout)
 
-        return set_lcd_timer
+        return set_lcd_timeout
 
 
 def _enroll_subcommands():

--- a/cometblue/cli.py
+++ b/cometblue/cli.py
@@ -126,7 +126,7 @@ class _HumanReadableFormatter(object):
         self._stream.flush()
 
     def print_lcd_timeout(self, value):
-        self._print_simple('Default timeout:\t%02u' % (value['default'])
+        self._print_simple('Default timeout:\t%02u' % (value['default']))
         self._print_simple('Timeout in progress:\t%02u' % (value['current']))
 
     def print_days(self, value):

--- a/cometblue/cli.py
+++ b/cometblue/cli.py
@@ -675,7 +675,7 @@ class _SetterFunctions(object):
                 raise RuntimeError(
                         'No status flags to update, try "status -h"')
 
-            if ctx.obj.device._device.is_connected():
+            if ctx.obj.device.is_connected():
                 current = ctx.obj.device.get_status()
                 current = dict((k, v) for k, v in current.items() if k in keys)
                 for k, v in status.items():

--- a/cometblue/cli.py
+++ b/cometblue/cli.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import sys
+import gatt
 
 import click
 import shellescape

--- a/cometblue/cli.py
+++ b/cometblue/cli.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 expandtab
 from __future__ import absolute_import

--- a/cometblue/device.py
+++ b/cometblue/device.py
@@ -78,6 +78,23 @@ def _decode_status(value):
     return report
 
 
+def _encode_status(value):
+    status_dword = 0
+    for key, state in value.items():
+        if not state:
+            continue
+
+        if not key in _STATUS_BITMASKS:
+            _log.error('Unknown flag ' + key)
+            continue
+
+        status_dword |= _STATUS_BITMASKS[key]
+
+    value = struct.pack('<I', status_dword)
+    # downcast to 3 bytes
+    return struct.pack(_STATUS_STRUCT_PACKING, *[int(byte) for byte in value[:3]])
+
+
 def _decode_temperatures(value):
     cur_temp, manual_temp, target_low, target_high, offset_temp, \
             window_open_detect, window_open_minutes = struct.unpack(
@@ -348,6 +365,7 @@ class CometBlue(object):
             'uuid': '47e9ee2a-47e9-11e4-8939-164230d1df67',
             'read_requires_pin': True,
             'decode': _decode_status,
+            'encode': _encode_status,
         },
 
         'temperatures': {

--- a/cometblue/device.py
+++ b/cometblue/device.py
@@ -320,11 +320,11 @@ class CometBlue(object):
             'encode': _encode_datetime,
         },
 
-        'flags': {
-            'description': 'flags',
+        'status': {
+            'description': 'status',
             'uuid': '47e9ee2a-47e9-11e4-8939-164230d1df67',
             'read_requires_pin': True,
-            'decode': _decode_flags,
+            'decode': _decode_status,
         },
 
         'temperatures': {

--- a/cometblue/device.py
+++ b/cometblue/device.py
@@ -720,6 +720,8 @@ class CometBlue(gatt.Device):
         try:
             super().disconnect()
             _log.info('Disconnected from device "%s"', self.mac_address)
+            self._cb_chars = None
+            self._cb_writes = {}
         except:
             _log.error('Failed disconnect from device "%s", considering disconnected anyway', self.mac_address)
 

--- a/cometblue/device.py
+++ b/cometblue/device.py
@@ -1,3 +1,4 @@
+# vim: tabstop=4 shiftwidth=4 expandtab
 from __future__ import absolute_import
 
 import datetime

--- a/cometblue/device.py
+++ b/cometblue/device.py
@@ -147,18 +147,18 @@ def _decode_battery(value):
     return value
 
 
-def _decode_lcd_timer(value):
-    preload, current = struct.unpack(_LCD_TIMER_STRUCT_PACKING, value)
+def _decode_lcd_timeout(value):
+    default, current = struct.unpack(_LCD_TIMER_STRUCT_PACKING, value)
     return {
-        'preload': preload,
+        'default': default,
         'current': current,
     }
 
 
-def _encode_lcd_timer(lcd_timer):
+def _encode_lcd_timeout(lcd_timeout):
     return struct.pack(
             _LCD_TIMER_STRUCT_PACKING,
-            lcd_timer['preload'],
+            lcd_timeout['default'],
             0)
 
 
@@ -396,12 +396,12 @@ class CometBlue(gatt.Device):
             'decode': _decode_str,
         },
 
-        'lcd_timer': {
-            'description': 'LCD timer',
+        'lcd_timeout': {
+            'description': 'LCD timeout',
             'uuid': '47e9ee2e-47e9-11e4-8939-164230d1df67',
             'read_requires_pin': True,
-            'decode': _decode_lcd_timer,
-            'encode': _encode_lcd_timer,
+            'decode': _decode_lcd_timeout,
+            'encode': _encode_lcd_timeout,
         },
 
         'pin': {

--- a/cometblue/discovery.py
+++ b/cometblue/discovery.py
@@ -1,3 +1,4 @@
+# vim: tabstop=4 shiftwidth=4 expandtab
 from __future__ import absolute_import
 
 import logging

--- a/cometblue/discovery.py
+++ b/cometblue/discovery.py
@@ -34,12 +34,12 @@ def discover(manager, timeout=10):
         name = _device.alias()
         address = _device.mac_address
         try:
-            with cometblue.device.CometBlue(_device, None) as device:
+            with _device as device:
                 manufacturer_name = device.get_manufacturer_name().lower()
                 model_number = device.get_model_number().lower()
 
                 if (manufacturer_name, model_number) in _SUPPORTED_DEVICES:
-                    filtered_devices[device._device.mac_address] = name
+                    filtered_devices[device.mac_address] = name
 
         except RuntimeError as exc:
             _log.debug('Skipping device "%s" ("%s") because of '

--- a/cometblue/discovery.py
+++ b/cometblue/discovery.py
@@ -16,10 +16,24 @@ _SUPPORTED_DEVICES = (
 
 _log = logging.getLogger(__name__)
 
+def probe_candidate(_device):
+    name = _device.alias()
+    address = _device.mac_address
+    try:
+        with _device as device:
+            manufacturer_name = device.get_manufacturer_name().lower()
+            model_number = device.get_model_number().lower()
 
-def discover(manager, timeout=10):
-    _log.info('Starting discovery on adapter "%s" with %u seconds timeout...',
-              manager.adapter_name, timeout)
+            if (manufacturer_name, model_number) in _SUPPORTED_DEVICES:
+                return (device.mac_address, str(name))
+
+    except RuntimeError as exc:
+        _log.debug('Skipping device "%s" ("%s"), reason: %r' % (name, address, str(exc)))
+    return None
+
+
+def discover_candidates(manager, timeout=10):
+    _log.info('Probing for candidate devices...')
 
     manager.start_discovery()
     time.sleep(timeout)
@@ -27,23 +41,17 @@ def discover(manager, timeout=10):
 
     devices = manager.devices()
     _log.debug('All discovered devices: %r', [(device.mac_address, str(device.alias())) for device in devices])
+    return devices
+
+def discover(manager, timeout=10):
+    _log.info('Starting discovery on adapter "%s" with %u seconds timeout...',
+              manager.adapter_name, timeout)
+    devices = discover_candidates(manager, timeout)
 
     filtered_devices = {}
-
-    for _device in devices:
-        name = _device.alias()
-        address = _device.mac_address
-        try:
-            with _device as device:
-                manufacturer_name = device.get_manufacturer_name().lower()
-                model_number = device.get_model_number().lower()
-
-                if (manufacturer_name, model_number) in _SUPPORTED_DEVICES:
-                    filtered_devices[device.mac_address] = name
-
-        except RuntimeError as exc:
-            _log.debug('Skipping device "%s" ("%s") because of '
-                       'exception: %r' % (name, address, exc))
-
+    for device in devices:
+        device_entry = cometblue.discovery.probe_candidate(device)
+        if not device_entry is None:
+            filtered_devices.update(dict([device_entry]))
     _log.info('Discovery finished')
     return filtered_devices

--- a/cometblue/discovery.py
+++ b/cometblue/discovery.py
@@ -17,10 +17,9 @@ _SUPPORTED_DEVICES = (
 _log = logging.getLogger(__name__)
 
 
-def discover(adapter='hci0', timeout=10):
+def discover(manager, timeout=10):
     _log.info('Starting discovery on adapter "%s" with %u seconds timeout...',
-              adapter, timeout)
-    manager = gatt.DeviceManager(adapter)
+              manager.adapter_name, timeout)
 
     manager.start_discovery()
     time.sleep(timeout)
@@ -35,9 +34,7 @@ def discover(adapter='hci0', timeout=10):
         name = _device.alias()
         address = _device.mac_address
         try:
-            with cometblue.device.CometBlue(
-                    address,
-                    adapter=adapter) as device:
+            with cometblue.device.CometBlue(_device, None) as device:
                 manufacturer_name = device.get_manufacturer_name().lower()
                 model_number = device.get_model_number().lower()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
-gattlib
+gatt
 pbr
 shellescape
 six

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [metadata]
 name = cometblue
 summary = Command line tool and python library for "Comet Blue" radiator thermostat
-author = Ivan Mironov
-author-email = mironov.ivan@gmail.com
-home-page = https://github.com/im-0/cometblue
+author = Ivan Mironov (original), Lukas Rucka (forked)
+author-email = xrucka@fi.muni.cz
+home-page = https://github.com/xrucka/cometblue
 classifier =
     Development Status :: 4 - Beta
     Environment :: Console
@@ -11,8 +11,7 @@ classifier =
     Intended Audience :: End Users/Desktop
     License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Operating System :: POSIX :: Linux
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
 keywords =
     cometblue
     bluetooth

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import setuptools
-
 
 setuptools.setup(
     setup_requires=['pbr'],


### PR DESCRIPTION
Hello,

I've ported the utility to use python3 with gatt-python library (dbus calls to bluez). However, there are some issues which pretty much reqiured to change the implementation of cli :-/ . Also, I've done some work on decoding the status bits and renamed the command. Please feel free to comment on.

The utility has been tested least by me for set+get+backup+restore. @miklik72 might be up to some testing as well (he's got a different model than I do) :-)

Regards, L.